### PR TITLE
Replace vim-markdown with better alternative.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "bundle/vim-gitgutter"]
 	path = bundle/vim-gitgutter
 	url = git://github.com/airblade/vim-gitgutter.git
+[submodule "bundle/vim-markdown-preview"]
+	path = bundle/vim-markdown-preview
+	url = git@github.com:JamshedVesuna/vim-markdown-preview.git


### PR DESCRIPTION
Upgraded to VIM 7.4 Patch 622 and realized that in patch 260 the vim-markdown plugin started alerting its internal errors.  Author may fix this but his issue log seems quite backed up.  I ended up finding one that I liked better however let me know if it doesn't have a feature you currently are using.

`https://github.com/JamshedVesuna/vim-markdown-preview`

This does introduce a dependency of markdown.pl which is BSD licensed and available here: http://daringfireball.net/projects/markdown/

Once downloaded move it to a location on your `PATH` then...
`mv markdown.pl markdown` 
`chmod +x markdown`

After that whenever you are editing a markdown file the default mapping is ctrl+p which will open a preview of the file you are browsing in your default browser.  It should autoupdate as you edit the file. 