### PR TITLE
Add Seeing Is Believing Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "bundle/vim-markdown-preview"]
 	path = bundle/vim-markdown-preview
 	url = git@github.com:JamshedVesuna/vim-markdown-preview.git
+[submodule "bundle/vim-seeing-is-believing"]
+	path = bundle/vim-seeing-is-believing
+	url = git@github.com:hwartig/vim-seeing-is-believing.git

--- a/vimrc
+++ b/vimrc
@@ -107,3 +107,8 @@ let g:vim_markdown_folding_disabled=1
 " covim
 let CoVim_default_name = "blainesch"
 let CoVim_default_port = "9180"
+
+" Ruby eval inline
+nnoremap <silent> <Leader>hm :execute "normal \<Plug>(seeing-is-believing-mark)"<CR>
+nnoremap <silent> <Leader>hb :execute "normal \<Plug>(seeing-is-believing-run)"<CR>
+


### PR DESCRIPTION
Allows you to mark and eval ruby code without leaving vim.
If you wouldn't like to add this then maybe just keep it as a feature branch on your repo.  
That way others can rebase their own master with it.

`gem install seeing_is_believing`
`,hm` to mark a line
`,hb` to eval a line